### PR TITLE
Reduce the amount of custom serialization work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 
 [dependencies]
 rustc_version = "0.4.0"
-semver = { version = "1.0.16", default-features = false }
-serde = { version = "1.0.152", default-features = false }
+semver = { version = "1.0.16", default-features = false, features = [ "serde" ] }
+serde = { version = "1.0.152", default-features = false, features = [ "derive", "alloc" ] }
 time = { version = "0.3.17", default-features = false, features = [ "serde" ] }
 
 [dev-dependencies]


### PR DESCRIPTION
The `semver` crate has an optional feature, and serde has built-in impls for String. Use an alternative shim type for rustc_version, which does not seem to have a serde feature.

Using a shim type avoids custom implementation of ser/de code, instead using a copy/pasted type that will
hopefully be optimized away (if all enum vals match)